### PR TITLE
Removes pathogen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,6 @@ principles:
 * allow people with different experiences to pair program proficiently and
   pleasantly
 
-It supports temporary installation of the Vim plugins by taking advantage
-of pathogen - useful for pairing sessions.
-
-If you are already using [pathogen.vim] (https://github.com/tpope/vim-pathogen),
-this distro can just be considered an extension of your existing setup.
-Chances are that you already have most of the third party plugins of this
-distro, as they are amongst the most popular.
-
-Credits are currently given in the form of links to the original source.
-Thanks to the great Vim community and to the many authors of the features.
-
 Content
 -------
 
@@ -30,7 +19,7 @@ Content
   - [Essentials](#essential-plugins)
   - [Nice-to-have's](#nice-to-have-plugins)
 * [Installing](#installing)
-  - [Install the Vim plugins (with pathogen)](#install-vim-plugins)
+  - [Install the Vim plugins](#install-vim-plugins)
   - [Install tmux 1.9 from source (only Ubuntu)](#install-tmux-source-ubuntu)
   - [Tmux configuration notes](#tmux-conf-notes)
   - [Updating existing Vim plugins](#update-existing-plugins)
@@ -153,9 +142,7 @@ Colorschemes:
 
 ## <a name="installing"></a>Installing
 
-Installation of tmux supports Ubuntu (tested on 12.04).
-
-The plugins use pathogen.
+Installation of tmux supports Ubuntu (tested on 20.04.6).
 
 It's useful to set Vim as default editor. If you wish to do so, put this
 in your `~/.bashrc` or `~/.bash_profile`:
@@ -166,7 +153,7 @@ in your `~/.bashrc` or `~/.bash_profile`:
 export EDITOR='/usr/bin/vim'
 ```
 
-### <a name="install-vim-plugins"></a>Install the Vim plugins (with pathogen)
+### <a name="install-vim-plugins"></a>Install the Vim plugins
 
 The list of essential and nice-to-have plugins is in `./vim-script/plugins`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@ To do
 * escape from buffergator
 * consider auto-correction
 * add open in split to git grep
-* merge `clone_to_bundle_with_home` into `install_plugin_with_pathogen`
 * add scripts for gnome-terminal profiles
 * reorganize plugins basic + by subject + get-all option
 * more statusline options: <http://got-ravings.blogspot.co.uk/2008/08/vim-pr0n-making-statuslines-that-own.html>
@@ -22,7 +21,6 @@ To do
 * add current word search to the grep helpers
 * Add Q&A section to the readme:
   - how is bouncing-vim different from, say, janus?
-  - why is it important to use pathogen instead of Vundle?
 * for plugins that end in ".vim" also check the presence of the folder without ".vim"
 * toggling lines C-n conflicts with multi-edit plugin
 * fix or remove leader not working in insert mode

--- a/rc-files/vimrc
+++ b/rc-files/vimrc
@@ -1,9 +1,3 @@
-" ================
-" === Pathogen ===
-" ================
-
-execute pathogen#infect()
-execute pathogen#helptags()
 
 " ===================
 " === Colorscheme ===

--- a/scripts/install-plugins
+++ b/scripts/install-plugins
@@ -43,30 +43,6 @@ fi
 
 ensure_vim_dir_structure
 
-# ================
-# === pathogen ===
-# ================
-
-# It will use pathogen if present, offer to install, or abort.
-
-if $is_a_clean_install; then
-  install_pathogen
-elif has_pathogen; then
-  echo "pathogen.vim is already installed"
-else
-  echo "pathogen.vim is required to install the vim plugins, but it is not installed"
-  select reply in "Install pathogen to handle your plugins" "Abort"; do
-    case "${reply}" in
-      "Install pathogen to handle your plugins" )
-        install_pathogen
-        break ;;
-      "Abort" )
-        echo "Note: pathogen.vim is required to install the vim plugins, aborting."
-        exit 1 ;;
-    esac
-  done
-fi
-
 # =============
 # === vimrc ===
 # =============
@@ -74,8 +50,7 @@ fi
 link_rcfile \
   "vimrc" \
   "
-NOTE: Make sure your vimrc initializes pathogen.
-You can also create a ~/.vimrc.after that will be loaded automatically."
+NOTE: You can also create a ~/.vimrc.after that will be loaded automatically."
 
 # =================
 # === tmux.conf ===
@@ -90,5 +65,5 @@ link_rcfile \
 # =======================
 
 for plugin in ${ESSENTIALS[@]}; do
-  install_plugin_with_pathogen "${plugin}"
+  install_plugin "${plugin}"
 done

--- a/scripts/install-plugins-noprompt
+++ b/scripts/install-plugins-noprompt
@@ -16,10 +16,8 @@ source "${CURRDIR}/vim-plugin-list.sh"
 
 ensure_vim_dir_structure
 
-install_pathogen
-
-ln -sfv "${HOME_DIR}/.vim/bundle/bouncing-vim/rc-files/vimrc" "${HOME_DIR}/.vimrc"
-ln -sfv "${HOME_DIR}/.vim/bundle/bouncing-vim/rc-files/tmux.conf" "${HOME_DIR}/.tmux.conf"
+ln -sfv "${HOME_DIR}/.vim/pack/bundle/start/bouncing-vim/rc-files/vimrc" "${HOME_DIR}/.vimrc"
+ln -sfv "${HOME_DIR}/.vim/pack/bundle/start/bouncing-vim/rc-files/tmux.conf" "${HOME_DIR}/.tmux.conf"
 
 for github_project in ${ESSENTIALS[@]}; do
   clone_to_bundle_with_home "${github_project}" "${HOME_DIR}"

--- a/scripts/install-plugins-with-nice-to-haves
+++ b/scripts/install-plugins-with-nice-to-haves
@@ -10,5 +10,5 @@ source "${CURRDIR}/vim-plugin-list.sh"
 "${CURRDIR}/install-plugins"
 
 for plugin in ${NICE_TO_HAVES[@]}; do
-  install_plugin_with_pathogen "$plugin"
+  install_plugin "$plugin"
 done

--- a/scripts/tmp-plugins-install
+++ b/scripts/tmp-plugins-install
@@ -12,9 +12,8 @@ This script allows you to install some plugins temporarily, for
 example during a pairing session.
 echo
 It will:
-- check if pathogen is installed
 - clone the plugins from github...
-- ...under ~/.vim/bundle with a name 'bouncing-vim-tmp-<plugin>'
+- ...under ~/.vim/pack/bundle/start with a name 'bouncing-vim-tmp-<plugin>'
 - skip the plugins the are already installed
 
 This is the list of plugins:
@@ -32,13 +31,6 @@ if [[ ! $REPLY =~ ^[Yy] ]]; then
   exit 1
 fi
 
-if ! has_pathogen; then
-  echo "
-pathogen.vim is required to use new temporary plugins
-but it is not installed. Exiting now."
-  exit 1
-fi
-
 for plugin in ${ESSENTIALS[@]}; do
-  install_tmp_plugin_with_pathogen "${plugin}"
+  install_tmp_plugin "${plugin}"
 done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -14,7 +14,7 @@ link_rcfile () {
 
   local rcfile_fullpath="${HOME}/.${rcfile}"
   local rcfile_bkp_path="${HOME}/${rcfile}.$(utc_timestamp).bkp"
-  local source_rcfile="${HOME}/.vim/bundle/bouncing-vim/rc-files/${rcfile}"
+  local source_rcfile="${HOME}/.vim/pack/bundle/start/bouncing-vim/rc-files/${rcfile}"
 
   if [[ $(readlink $rcfile_fullpath) == $source_rcfile ]]; then
     echo "$rcfile is already linking to the provided rcfile"
@@ -49,7 +49,7 @@ clone_to_bundle_with_home () {
   local home_dir=$2
 
   local github_basename=$(get_github_basename $github_project)
-  local plugin_dir="${home_dir}/.vim/bundle/$github_basename"
+  local plugin_dir="${home_dir}/.vim/pack/bundle/start/$github_basename"
 
   if [[ ! -d "${plugin_dir}" ]]; then
     echo "[install] $github_project -> ${plugin_dir}"
@@ -62,16 +62,17 @@ clone_to_bundle_with_home () {
 _get_std_plugin_dir () {
   local github_project=$1
   local github_basename=$(get_github_basename $github_project)
-  echo "${HOME}/.vim/bundle/${github_basename}"
+  #vim plugins should be sit in `.vim/pack/bundle/start/` dirrectory
+  echo "${HOME}/.vim/pack/bundle/start/${github_basename}"
 }
 
 _get_tmp_plugin_dir () {
   local github_project=$1
   local github_basename=$(get_github_basename $github_project)
-  echo "${HOME}/.vim/bundle/bouncing-vim-tmp-${github_basename}"
+  echo "${HOME}/.vim/pack/bundle/start/bouncing-vim-tmp-${github_basename}"
 }
 
-install_plugin_with_pathogen () {
+install_plugin () {
   local github_project=$1
   local std_plugin_dir=$(_get_std_plugin_dir "${github_project}")
   local tmp_plugin_dir=$(_get_tmp_plugin_dir "${github_project}")
@@ -87,7 +88,7 @@ install_plugin_with_pathogen () {
   fi
 }
 
-install_tmp_plugin_with_pathogen () {
+install_tmp_plugin () {
   local github_project=$1
 
   local std_plugin_dir=$(_get_std_plugin_dir "${github_project}")
@@ -101,24 +102,8 @@ install_tmp_plugin_with_pathogen () {
   fi
 }
 
-has_pathogen () {
-  if [[ -n $(find ~/.vim -name pathogen.vim) ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-install_pathogen () {
-  ensure_curl
-
-  echo "Install pathogen to handle your plugins"
-  curl -L -o ~/.vim/autoload/pathogen.vim \
-    https://raw.github.com/tpope/vim-pathogen/master/autoload/pathogen.vim
-}
-
 ls_tmp_plugins () {
-  find "${HOME}/.vim/bundle/" -type d -iname 'bouncing-vim-tmp-*'
+  find "${HOME}/.vim/pack/bundle/start/" -type d -iname 'bouncing-vim-tmp-*'
 }
 
 archive_tmp_plugins () {
@@ -143,6 +128,5 @@ ensure_curl () {
 
 ensure_vim_dir_structure () {
   echo "Ensure a complete ~/.vim dir structure"
-  mkdir -v -p ~/.vim/{bundle,autoload,colors,undo,swap,_disabled_plugins}
+  mkdir -v -p ~/.vim/{bundle,pack/bundle/start,autoload,colors,undo,swap,_disabled_plugins}
 }
-

--- a/snippets
+++ b/snippets
@@ -209,10 +209,6 @@ endfunction
 
 autocmd! FileType qf call SetOpenQuickfixItemsInSplits()
 
-# Alternative pathogen installation
------------------------------------
-# git clone https://github.com/tpope/vim-pathogen.git ~/.vim/vim-pathogen
-# ln -sf ~/.vim/vim-pathogen/autoload/pathogen.vim ~/.vim/autoload/pathogen.vim
 
 " ==================
 " === Leader key ===


### PR DESCRIPTION
Tested on tmux(Ubuntu 20.04.6)
Instead leverages default vim package manager - `.vim/pack/bundle/start`.